### PR TITLE
cPanel MX records sync

### DIFF
--- a/sync_dns.py
+++ b/sync_dns.py
@@ -121,8 +121,11 @@ def sync_zone(domain_records_url, domain):
                 weight = None
                 if rset.rdtype == MX:
                     priority = rdata.preference
-                    data = rdata.exchange
                     print "--> Priority:", priority
+                    if unicode(rdata.exchange) == "@":
+                        data = domain + "."
+                    else:
+                        data = rdata.exchange
                 elif rset.rdtype == CNAME:
                     if unicode(rdata) == "@":
                         data = "@"


### PR DESCRIPTION
I had a problem syncing from a cPanel server where the MX record is the domain name (not a subdomain, or external domain)

This might not be pretty, but it seems to work for me.